### PR TITLE
Fixing path issues for Windows when starting phantomjs

### DIFF
--- a/tasks/lib/PhantomJsHeadlessAnalyzer.js
+++ b/tasks/lib/PhantomJsHeadlessAnalyzer.js
@@ -192,7 +192,8 @@ function turnUrlIntoRelativeDirectory(relativeTo, url) {
     if (/^http:/.test(url)) {
         url = url.substring("http://localhost:3000/".length);
     }
-    return path.relative(relativeTo, url.substring(0, url.lastIndexOf("/")));
+	url = path.normalize(url);
+    return path.relative(relativeTo, url.substring(0, url.lastIndexOf(path.sep)));
 }
 
 PhantomJsHeadlessAnalyzer.prototype.startWebServerToHostPage = function (tempPage) {


### PR DESCRIPTION
A problem occured when phantomjs spawned on windows. It would include script tags with the wrong relative source.
