### PR TITLE
Fixes #40

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt-lib-phantomjs": "~0.3.0",
-    "phantomjs": "1.9.0-6",
+    "grunt-lib-phantomjs": "~0.7.1",
+    "phantomjs": "1.9.20",
     "connect": "~2.7.11"
   },
   "devDependencies": {


### PR DESCRIPTION
I've updated `phantomjs` to the latest 1.9.x and `grunt-lib-phantomjs` to 0.7.1 as that's the last release that still uses `phantomjs` from the 1.9 line.
